### PR TITLE
Added a metadata to store maximum offset set to true. This enables th…

### DIFF
--- a/serde/src/test/java/org/splicer/serde/encoder/MapToRoaringBitmapEncoderTest.java
+++ b/serde/src/test/java/org/splicer/serde/encoder/MapToRoaringBitmapEncoderTest.java
@@ -46,9 +46,17 @@ public class MapToRoaringBitmapEncoderTest {
 
         assertEquals(markerInt, max);
 
-        final byte[] roaringBitMapArray = new byte[byteArray.length - marker.length];
+        byte[] maxBitBytes = new byte[4];
 
-        System.arraycopy(byteArray, marker.length, roaringBitMapArray, 0, roaringBitMapArray.length);
+        System.arraycopy(byteArray, marker.length, maxBitBytes, 0, maxBitBytes.length);
+
+        int maxOffsetSetToTrue = Ints.fromByteArray(maxBitBytes);
+
+        assertEquals(maxOffsetSetToTrue, 10000);
+
+        final byte[] roaringBitMapArray = new byte[byteArray.length - 8];
+
+        System.arraycopy(byteArray, marker.length + maxBitBytes.length, roaringBitMapArray, 0, roaringBitMapArray.length);
 
         RoaringBitmap roaringBitmap = new RoaringBitmap();
 


### PR DESCRIPTION
…e decoder or reader to skip deserializing the roaring bitmap if the asking offset is more than what it was stored.
